### PR TITLE
fix typo on exception name

### DIFF
--- a/schemaman/datasource/mysql_handler/query.py
+++ b/schemaman/datasource/mysql_handler/query.py
@@ -81,7 +81,7 @@ class Connection:
       self.Close()
     
     # Ignore this failure, this happens when the context is lost, because the program is closing, and we are working with NoneTypes, instead of expected types
-    except (Type, AttributeError), e:
+    except (TypeError, AttributeError), e:
       pass
 
 


### PR DESCRIPTION
This isn't causing errors during run-time, but it does print out an error in interpreter shutdown